### PR TITLE
UI improvements

### DIFF
--- a/assets/script/books.js
+++ b/assets/script/books.js
@@ -45,7 +45,7 @@ function filterPublishers(publisher) {
     $('#books').children().hide();
     var matchingBooks = $("article p[itemprop='publisher']:contains(" + publisher +")").closest("article");
     var numberFound = matchingBooks.length;
-    
+
     $('#sort').hide();
     matchingBooks.show();
     if(numberFound === 1) {
@@ -64,11 +64,11 @@ function sortByPublisher() {
     pub_a = $(a).find('p[itemprop="publisher"]')[0].textContent.trim();
     title_a = $(a).find('h2')[0].textContent.trim();
     sort_key_a = pub_a.trim() + "__" + title_a.trim().replace(/^(The )|(A )/, "");
-    
+
     pub_b = $(b).find('p[itemprop="publisher"]')[0].textContent.trim();
     title_b = $(b).find('h2')[0].textContent.trim();
     sort_key_b = pub_b.trim() + "__" + title_b.trim().replace(/^(The )|(A )/, "");
-    
+
     return sort_key_a.toLowerCase().localeCompare(sort_key_b.toLowerCase());
   });
   $('#pub_sort').hide();
@@ -80,10 +80,10 @@ function sortByTitle() {
   $('article').sortElements(function(a, b){
     title_a = $(a).find('h2')[0].textContent.trim();
     sort_key_a = title_a.trim().replace(/^(The )|(A )/, "");
-    
+
     title_b = $(b).find('h2')[0].textContent.trim();
     sort_key_b = title_b.trim().replace(/^(The )|(A )/, "");
-    
+
     return sort_key_a.toLowerCase().localeCompare(sort_key_b.toLowerCase());
   });
   $('#title_sort').hide();

--- a/assets/script/books.js
+++ b/assets/script/books.js
@@ -13,12 +13,9 @@ var main = function() {
 $(document).ready(main);
 
 function revealInfo(image) {
-  hideInfo();
-  $('#fade').css('height', $(window).height());
   $('#fade').show();
   var infoPanel = $(image).parent().find('.about');
   infoPanel.show();
-  infoPanel.css({margin:$(document).scrollTop()+100+'px 0 0 '+($(window).width() / 2 - infoPanel.width() / 2)+'px'});
   if(infoPanel.find('tab_set')) {
     $('.tab_content').hide();
     $(infoPanel.find('.tab_content')[0]).show();

--- a/bin/lib/book_binder.rb
+++ b/bin/lib/book_binder.rb
@@ -104,7 +104,7 @@ module BookBinder
     subfolders.each do |subfolder_name|
       if File.exist?("#{subfolder_name}/_meta/info.js")
         edition_info = JSON.parse(File.read("#{subfolder_name}/_meta/info.js")).symbolize_keys
-        book_info[:isbn] = edition_info[:isbn] if edition_info[:isbn] && !book_info[:isbn]
+        book_info[:isbn] = edition_info[:ISBN] if edition_info[:ISBN] && !book_info[:isbn]
         edition_info.delete(:ISBN)
         book_info[:publisher] = edition_info.delete(:publisher)
         ident = "#{book_info[:isbn]}_#{ident_no}"

--- a/bin/lib/bookshelf.rb
+++ b/bin/lib/bookshelf.rb
@@ -9,6 +9,8 @@ require_relative 'book_binder'
 class Bookshelf
   attr_reader :books, :publishers, :incompletes, :strays
 
+  SELFPUB_NAME = "Self published".freeze
+
   def initialize(shelf_folder)
     @books = []
     @publishers = []
@@ -73,7 +75,16 @@ class Bookshelf
     @books = book_data[:books]
     @incompletes = book_data[:incompletes]
     @strays = book_data[:strays]
-    @publishers = book_data[:publishers].uniq!
+    @publishers = sort_publishers(book_data[:publishers].uniq)
+  end
+
+  def sort_publishers(pubs)
+    self_published = pubs.delete("")
+    sorted = pubs.sort
+    if self_published
+      sorted << SELFPUB_NAME
+    end
+    sorted
   end
 
   def generate_css(sass_file)

--- a/bin/lib/edition.rb
+++ b/bin/lib/edition.rb
@@ -12,12 +12,7 @@ class Edition < Publication
     @authors = authors || book.authors
     @notes = notes || book.notes
     @formats = get_formats
-    @title =
-      if title
-        "#{book.title} - #{title}"
-      else
-        book.title
-      end
+    @title = title || book.title
     @publisher = book.publisher
   end
 

--- a/bin/lib/publication.rb
+++ b/bin/lib/publication.rb
@@ -12,6 +12,10 @@ class Publication
     end
   end
 
+  def self_published?
+    @publisher == ""
+  end
+
   def editions ; end
 
   def cover_pic

--- a/bin/lib/publication.rb
+++ b/bin/lib/publication.rb
@@ -43,7 +43,7 @@ class Publication
       _formats << format
     end
 
-    _formats
+    _formats.sort_by! { |key| key[:name] }
   end
 
   def get_book_files

--- a/bin/style/style.scss
+++ b/bin/style/style.scss
@@ -183,3 +183,21 @@ article[itemtype="http://schema.org/Book"] {
   opacity: 0.7;
   display: none;
 }
+
+.ribbon:before{
+  font-weight: bold;
+  font-size: 12px;
+  content: 'more editions';
+  background-color: black;
+  color: white;
+  padding: 0;
+  margin: -10px 16%;
+  top: 6px;
+  width: 115px;
+  height: 16px;
+  text-align: center;
+  position: relative;
+  display: inline-block;
+  float: right;
+  box-shadow:1px 1px 4px rgba(0,0,0,0.5)
+}

--- a/bin/style/style.scss
+++ b/bin/style/style.scss
@@ -87,10 +87,12 @@ article[itemtype="http://schema.org/Book"] {
       padding: 0.4em;
       padding-bottom: 0;
       border-bottom: 0;
-      min-width: 375px;
+      width: 100%;
       position: relative;
       list-style: none;
-      
+
+      ul { width: 100%; }
+
       .tab_button {
         z-index: 0;
         margin: 0 4px;

--- a/bin/style/style.scss
+++ b/bin/style/style.scss
@@ -188,9 +188,7 @@ article[itemtype="http://schema.org/Book"] {
 }
 
 .notes {
-  font-family: cursive;
-  word-spacing: 0.5em;
-  color: green;
+  color: #651b1b;
 }
 
 #fade {

--- a/bin/style/style.scss
+++ b/bin/style/style.scss
@@ -3,14 +3,25 @@ $icon-spec: no-repeat 0 50%;
 $book-tile-width: 170px;
 $book-tile-height: 230px;
 
-body { 
-  margin: 1em;
+body {
+  margin: 0 !important;
+  padding: 0 !important;
   font-family: $font-stack;
   padding: 1em 0;
 }
 
-a { text-decoration: none; }
+header {
+  position: fixed;
+  background: white;
+  padding: 0 1em;
+  margin: 0;
+  top: 0 !important;
+  width: 100%;
+  height: 120px;
+  z-index: 10;
+}
 
+a { text-decoration: none; }
 
 img[itemprop="image"] {
   padding: 0;
@@ -21,12 +32,20 @@ img[itemprop="image"] {
   &:hover { cursor: pointer }
 }
 
+section#books {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  grid-column-gap: 5px;
+  width: 90%;
+  margin: 0 auto;
+  position: absolute;
+  top: 120px;
+}
+
 article[itemtype="http://schema.org/Book"] {
   margin: 10px 15px;
   float: left;
   text-align: center;
-  display: flex;
-  flex-direction: column;
   min-height: $book-tile-height;
   min-width: $book-tile-width;
 
@@ -36,21 +55,22 @@ article[itemtype="http://schema.org/Book"] {
     max-width: 12em;
     min-width: $book-tile-width;
     min-height: 3.5em;
-    
+
     a { color: black;}
-    
   }
-  
+
   .about {
-    position: absolute;
+    position: fixed;
+    top: 60%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    x-margin-top: 120px;
+    display: block;
     padding: 0em;
     font-size: 1em;
     background-color: white;
-    top: 0;
-    left: 0;
-    z-index: 10;
-    width: 60%;
-    height: auto;
+    z-index: 9;
+    max-width: 550px;
     display: none;
     border: 1px solid darkgrey;
     min-width: 413px;
@@ -173,15 +193,14 @@ article[itemtype="http://schema.org/Book"] {
 }
 
 #fade {
-  position: absolute;
+  display: none;
   width: 100%;
   height: 100%;
-  top: 0;
+  position: fixed;
   left: 0;
-  z-index: 1;
-  background-color: white;
-  opacity: 0.7;
-  display: none;
+  top: 0;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 8;
 }
 
 .ribbon:before{

--- a/bin/style/style.scss
+++ b/bin/style/style.scss
@@ -72,7 +72,7 @@ article[itemtype="http://schema.org/Book"] {
     max-width: 550px;
     display: none;
     border: 1px solid darkgrey;
-    min-width: 413px;
+    min-width: 450px;
 
     h1 {
       margin: 2px;

--- a/bin/style/style.scss
+++ b/bin/style/style.scss
@@ -161,11 +161,12 @@ article[itemtype="http://schema.org/Book"] {
       line-height: 1.5em;
       list-style: none;
       text-align: left;
+    }
 
-      .formats {
-        padding: 0;
-        list-style: none;
-      }
+    ul.formats {
+      padding: 0;
+      list-style: none;
+      min-height: 74px;
     }
 
     li {

--- a/bin/style/style.scss
+++ b/bin/style/style.scss
@@ -28,7 +28,6 @@ img[itemprop="image"] {
   margin: auto;
   background-color: #fff;
   flex: none;
-  
   &:hover { cursor: pointer }
 }
 
@@ -80,7 +79,7 @@ article[itemtype="http://schema.org/Book"] {
       border: 1px solid darkgrey;
       padding: 0.4em;
     }
-    
+
     .tab_set {
       border: 1px solid darkgrey;
       margin: 2px 2px -3px 2px;
@@ -101,24 +100,23 @@ article[itemtype="http://schema.org/Book"] {
         background: darken(#ECECEC, 7%);
         display: inline-block;
         z-index: 4;
-        
+
         &:hover {
           cursor: pointer;
           background: #ECECEC;
         }
       }
-      
+
       .tab_button.selected {
         z-index: 2;
         background: white;
         border-bottom: 1px solid #fff;
-        
         &:hover {
           cursor: default;
         }
       }
     }
-    
+
     .content {
       border: 1px solid darkgrey;
       margin: 2px;
@@ -126,21 +124,21 @@ article[itemtype="http://schema.org/Book"] {
       position: relative;
       min-width: 375px;
       z-index: -1;
-      
+
       .coverpic {
         position: absolute;
         top: 1em;
         right: 1em;
       }
-      
+
       .info_column {
         min-width: 240px;
       }
-      
+
       .tab_content {
         display: none;
       }
-      
+
       .tabs :first-child {
         display: block;
       }
@@ -152,7 +150,7 @@ article[itemtype="http://schema.org/Book"] {
       min-height: 0;
       font-size: 1em;
     }
-    
+
     h2, ul, p, span {
       width: 70%;
     }

--- a/bin/test/book_test.rb
+++ b/bin/test/book_test.rb
@@ -159,4 +159,12 @@ class TestBook < Minitest::Test
     end
   end
 
+  describe '#self_published?' do
+    let(:self_published_book) { Book.new }
+    let(:trad_published_book) { Book.new(publisher: 'test') }
+
+    it { assert_equal(self_published_book.self_published?, true) }
+    it { assert_equal(trad_published_book.self_published?, false) }
+  end
+
 end

--- a/bin/test/edition_test.rb
+++ b/bin/test/edition_test.rb
@@ -51,7 +51,7 @@ class TestEdition < Minitest::Test
 
       it { assert_equal(book.isbn, edition.isbn) }
       it { assert_equal("2nd printing", edition.notes) }
-      it { assert_equal("The Complete Works - 2008 edit", edition.title) }
+      it { assert_equal("2008 edit", edition.title) }
     end
   end
 

--- a/bin/views/_book.html.erb
+++ b/bin/views/_book.html.erb
@@ -1,4 +1,4 @@
-      <article itemscope itemtype="http://schema.org/Book" id="book_<%= @uniq %>" class="book">
+      <article itemscope itemtype="http://schema.org/Book" id="book_<%= @uniq %>" class="book <%= "ribbon" if @book.editions? %>">
 <% if @book.cover_pic %>
         <img itemprop="image" src="<%= @book.cover_pic %>" alt="<%= @book.title %>" onclick="revealInfo(this);"/>
 <% else %>

--- a/bin/views/_detail.html.erb
+++ b/bin/views/_detail.html.erb
@@ -7,7 +7,7 @@
               </ul>
 
               <h2>Publisher</h2>
-              <p itemprop="publisher"><%= @book.publisher %></p>
+              <p itemprop="publisher"><%= @book.self_published? ? Bookshelf::SELFPUB_NAME : @book.publisher %></p>
 <% if @book.notes %>
               <h2>Notes</h2>
               <p class="notes"><%= @book.notes %></p>

--- a/bin/views/index.html.erb
+++ b/bin/views/index.html.erb
@@ -16,7 +16,7 @@
             <label for="pubfilter">Filter by publisher</label>
             <select id="pubfilter" class="pubfilter">
               <option>Show All</option><% @publishers.each do |pub| %>
-              <option><%= pub %></option><% end %>
+              <option><%= pub == "" ? Bookshelf::SELFPUB_NAME : pub %></option><% end %>
             </select>
           </form>
         </div>


### PR DESCRIPTION
## Fixups
* Minor styling tweaks to colours (and removed past me's weird font choice)
* Uses flex grid to flow the layout in a less janky way
* Displays available formats in a predictable order rather than 🤷
* Hacky fix for reading in ISBNs values properly
* Introduces a fixed position header so the controls don't scroll off the screen when you have 8-12 books to browse through

## Editions

Adds an indicator for books which have multiple editions

<img width="169" alt="Screenshot 2020-07-22 at 23 34 08" src="https://user-images.githubusercontent.com/27760/88235973-e300b080-cc73-11ea-8ee8-45aa9fa401bf.png">

Makes the edition tabs more usable (and more obviously tabs!)

| Before | After |
| ------- | ----- |
| <img width="322" alt="Screenshot 2020-07-22 at 23 23 46" src="https://user-images.githubusercontent.com/27760/88235551-024b0e00-cc73-11ea-87fb-9361ad146a24.png"> | <img width="230" alt="Screenshot 2020-07-22 at 23 24 01" src="https://user-images.githubusercontent.com/27760/88235749-653ca500-cc73-11ea-91d8-5411c34fd712.png"> |


## "Self published"

Books without a named publisher will now appear under "Self published" in the "Sort by publisher" dropdown rather than only being visible in the **everything** view.

<img width="380" alt="Screenshot 2020-07-22 at 23 45 34" src="https://user-images.githubusercontent.com/27760/88236703-83a3a000-cc75-11ea-8a0d-02a8052c3234.png">

If "Self published" seems impolite (it's not supposed to), it's just a constant in the `Bookshelf` class so you - or future me if any writer friends take to throwing things at me - can change it in just one place and never see it in the UI again.