### PR TITLE
Add book search

### DIFF
--- a/assets/script/books.js
+++ b/assets/script/books.js
@@ -1,6 +1,7 @@
 var main = function() {
   $('.pubfilter').change(function() {
     var selectedPub = $(this).val();
+    if(selectedPub) { clearSearchBox(); }
     filterPublishers(selectedPub);
   });
   $('#select_info').hide();
@@ -26,6 +27,10 @@ function revealInfo(image) {
 function hideInfo() {
   $('.about').hide();
   $('#fade').hide();
+}
+
+function clearSearchBox() {
+  $('#search_box').val("");
 }
 
 function clearPublishers() {
@@ -124,3 +129,34 @@ function showMoreInfo(isbn, book_id) {
     }
   });
 }
+
+function searchAuthors(form) {
+  hideInfo();
+  clearPublishers();
+  $('#title_sort').hide();
+  $('#pub_sort').hide();
+  $('#select_info').hide();
+  let author = form.search_box.value;
+  let matchingBooks = $("article ul[class='authors']:contains(" + author +")").closest("article");
+  $('#books').children().hide();
+  let numberFound = matchingBooks.length;
+  matchingBooks.show();
+
+  if(numberFound === 1) {
+    var bookStr = "book";
+  } else {
+    var bookStr = "books";
+  }
+
+  $('#select_info').html('Found <strong>' + matchingBooks.length + '</strong> ' + bookStr + ' matching "<strong>' + author + '</strong>"');
+  $('#select_info').show();
+}
+
+// case insensitive modifier for jQuery :contains
+// lifted from CSS Tricks
+// https://css-tricks.com/snippets/jquery/make-jquery-contains-case-insensitive/
+$.expr[":"].contains = $.expr.createPseudo(function(arg) {
+  return function( elem ) {
+    return $(elem).text().toUpperCase().indexOf(arg.toUpperCase()) >= 0;
+  };
+});

--- a/assets/script/books.js
+++ b/assets/script/books.js
@@ -13,6 +13,8 @@ var main = function() {
 
 $(document).ready(main);
 
+let validSearchOperators = ['title', 'author']
+
 function revealInfo(image) {
   $('#fade').show();
   var infoPanel = $(image).parent().find('.about');
@@ -136,13 +138,26 @@ function searchBooks(form) {
   $('#title_sort').hide();
   $('#pub_sort').hide();
   $('#nav_info').hide();
-  let search_term = form.search_box.value;
-  let matchingAuthors = $("article ul[class='authors']:contains(" + search_term +")").closest("article");
-  let matchingBooks = $("article a[itemprop='name']:contains(" + search_term +")").closest("article");
   $('#books').children().hide();
+
+  let matchingAuthors = []
+  let matchingBooks = []
+
+  let raw_term = form.search_box.value;
+  let search_operator = getSearchOperator(raw_term);
+  let search_term = raw_term.replace(search_operator + ':', '').trim();
+
+  if(!search_operator || search_operator == 'author') {
+    matchingAuthors = searchAuthors(search_term);
+  }
+
+  if(!search_operator || search_operator == 'title') {
+    matchingBooks = searchTitles(search_term);
+  }
+
   let numberFound = matchingBooks.length + matchingAuthors.length;
-  matchingAuthors.show();
-  matchingBooks.show();
+  if (matchingAuthors.length > 0) { matchingAuthors.show(); }
+  if (matchingBooks.length > 0) { matchingBooks.show(); }
 
   if(numberFound === 1) {
     var bookStr = "book";
@@ -152,6 +167,23 @@ function searchBooks(form) {
 
   $('#nav_info').html('Found <strong>' + numberFound + '</strong> ' + bookStr + ' matching "<strong>' + search_term + '</strong>"');
   $('#nav_info').show();
+}
+
+function searchAuthors(term) {
+  return $("article ul[class='authors']:contains(" + term + ")").closest("article");
+}
+
+function searchTitles(term) {
+  return $("article a[itemprop='name']:contains(" + term + ")").closest("article");
+}
+
+function getSearchOperator(query) {
+  candidate = query.split(':')[0]
+  if(jQuery.inArray(candidate, validSearchOperators) !== -1) {
+    return candidate;
+  } else {
+    return null;
+  }
 }
 
 // case insensitive modifier for jQuery :contains

--- a/assets/script/books.js
+++ b/assets/script/books.js
@@ -142,7 +142,7 @@ function searchBooks(form) {
   if (matchingAuthors.length > 0) { matchingBooks = matchingBooks.add(matchingAuthors) }
   if (matchingTitles.length > 0) { matchingBooks = matchingBooks.add(matchingTitles) }
 
-  matchingBooks.show();
+  matchingBooks.sortElements(titleSort()).show();
 
   let numberFound = matchingBooks.length;
 

--- a/assets/script/books.js
+++ b/assets/script/books.js
@@ -137,9 +137,11 @@ function searchAuthors(form) {
   $('#pub_sort').hide();
   $('#select_info').hide();
   let author = form.search_box.value;
-  let matchingBooks = $("article ul[class='authors']:contains(" + author +")").closest("article");
+  let matchingAuthors = $("article ul[class='authors']:contains(" + author +")").closest("article");
+  let matchingBooks = $("article a[itemprop='name']:contains(" + author +")").closest("article");
   $('#books').children().hide();
-  let numberFound = matchingBooks.length;
+  let numberFound = matchingBooks.length + matchingAuthors.length;
+  matchingAuthors.show();
   matchingBooks.show();
 
   if(numberFound === 1) {
@@ -148,7 +150,7 @@ function searchAuthors(form) {
     var bookStr = "books";
   }
 
-  $('#select_info').html('Found <strong>' + matchingBooks.length + '</strong> ' + bookStr + ' matching "<strong>' + author + '</strong>"');
+  $('#select_info').html('Found <strong>' + numberFound + '</strong> ' + bookStr + ' matching "<strong>' + author + '</strong>"');
   $('#select_info').show();
 }
 

--- a/assets/script/books.js
+++ b/assets/script/books.js
@@ -130,15 +130,15 @@ function showMoreInfo(isbn, book_id) {
   });
 }
 
-function searchAuthors(form) {
+function searchBooks(form) {
   hideInfo();
   clearPublishers();
   $('#title_sort').hide();
   $('#pub_sort').hide();
-  $('#select_info').hide();
-  let author = form.search_box.value;
-  let matchingAuthors = $("article ul[class='authors']:contains(" + author +")").closest("article");
-  let matchingBooks = $("article a[itemprop='name']:contains(" + author +")").closest("article");
+  $('#nav_info').hide();
+  let search_term = form.search_box.value;
+  let matchingAuthors = $("article ul[class='authors']:contains(" + search_term +")").closest("article");
+  let matchingBooks = $("article a[itemprop='name']:contains(" + search_term +")").closest("article");
   $('#books').children().hide();
   let numberFound = matchingBooks.length + matchingAuthors.length;
   matchingAuthors.show();
@@ -150,7 +150,7 @@ function searchAuthors(form) {
     var bookStr = "books";
   }
 
-  $('#select_info').html('Found <strong>' + numberFound + '</strong> ' + bookStr + ' matching "<strong>' + author + '</strong>"');
+  $('#select_info').html('Found <strong>' + numberFound + '</strong> ' + bookStr + ' matching "<strong>' + search_term + '</strong>"');
   $('#select_info').show();
 }
 

--- a/assets/script/books.js
+++ b/assets/script/books.js
@@ -141,7 +141,8 @@ function searchBooks(form) {
   $('#books').children().hide();
 
   let matchingAuthors = []
-  let matchingBooks = []
+  let matchingTitles = []
+  let matchingBooks = $("article ul[class='zero-results']");
 
   let raw_term = form.search_box.value;
   let search_operator = getSearchOperator(raw_term);
@@ -152,12 +153,15 @@ function searchBooks(form) {
   }
 
   if(!search_operator || search_operator == 'title') {
-    matchingBooks = searchTitles(search_term);
+    matchingTitles = searchTitles(search_term);
   }
 
-  let numberFound = matchingBooks.length + matchingAuthors.length;
-  if (matchingAuthors.length > 0) { matchingAuthors.show(); }
-  if (matchingBooks.length > 0) { matchingBooks.show(); }
+  if (matchingAuthors.length > 0) { matchingBooks = matchingBooks.add(matchingAuthors) }
+  if (matchingTitles.length > 0) { matchingBooks = matchingBooks.add(matchingTitles) }
+
+  matchingBooks.show();
+
+  let numberFound = matchingBooks.length;
 
   if(numberFound === 1) {
     var bookStr = "book";

--- a/assets/script/books.js
+++ b/assets/script/books.js
@@ -28,6 +28,20 @@ function hideInfo() {
   $('#fade').hide();
 }
 
+function clearPublishers() {
+  $('.pubfilter').val("");
+}
+
+function resetPublishers() {
+  $('.pubfilter').val("Show All");
+}
+
+function resetState() {
+  hideInfo();
+  $('#pub_sort').show();
+  $('#title_sort').hide();
+}
+
 function showTab(tab) {
   $('.tab_content').hide();
   $('#' + tab).show();
@@ -36,7 +50,7 @@ function showTab(tab) {
 }
 
 function filterPublishers(publisher) {
-  hideInfo();
+  resetState();
   if(publisher === 'Show All') {
     $('#books').children().show();
     $('#sort').show();
@@ -77,6 +91,7 @@ function sortByPublisher() {
 
 function sortByTitle() {
   hideInfo();
+  resetPublishers();
   $('article').sortElements(function(a, b){
     title_a = $(a).find('h2')[0].textContent.trim();
     sort_key_a = title_a.trim().replace(/^(The )|(A )/, "");
@@ -89,7 +104,6 @@ function sortByTitle() {
   $('#title_sort').hide();
   $('#pub_sort').show();
 }
-
 
 function showMoreInfo(isbn, book_id) {
   target = "https://openlibrary.org/api/books?bibkeys=ISBN:" + isbn.trim() + "&jscmd=data&format=json";

--- a/assets/script/books.js
+++ b/assets/script/books.js
@@ -4,7 +4,7 @@ var main = function() {
     if(selectedPub) { clearSearchBox(); }
     filterPublishers(selectedPub);
   });
-  $('#select_info').hide();
+  $('#nav_info').hide();
   $('#title_sort').hide();
   $('#pub_sort').click(function() {sortByPublisher();});
   $('#title_sort').click(function() {sortByTitle();});
@@ -59,7 +59,7 @@ function filterPublishers(publisher) {
   if(publisher === 'Show All') {
     $('#books').children().show();
     $('#sort').show();
-    $('#select_info').hide();
+    $('#nav_info').hide();
   } else {
     $('#books').children().hide();
     var matchingBooks = $("article p[itemprop='publisher']:contains(" + publisher +")").closest("article");
@@ -72,8 +72,8 @@ function filterPublishers(publisher) {
     } else {
       var bookStr = "books";
     }
-    $('#select_info').html('Found <strong>' + matchingBooks.length + '</strong> ' + bookStr + ' for <strong>' + publisher + '</strong>');
-    $('#select_info').show();
+    $('#nav_info').html('Found <strong>' + matchingBooks.length + '</strong> ' + bookStr + ' for <strong>' + publisher + '</strong>');
+    $('#nav_info').show();
   }
 }
 
@@ -150,8 +150,8 @@ function searchBooks(form) {
     var bookStr = "books";
   }
 
-  $('#select_info').html('Found <strong>' + numberFound + '</strong> ' + bookStr + ' matching "<strong>' + search_term + '</strong>"');
-  $('#select_info').show();
+  $('#nav_info').html('Found <strong>' + numberFound + '</strong> ' + bookStr + ' matching "<strong>' + search_term + '</strong>"');
+  $('#nav_info').show();
 }
 
 // case insensitive modifier for jQuery :contains

--- a/assets/script/books.js
+++ b/assets/script/books.js
@@ -81,17 +81,7 @@ function filterPublishers(publisher) {
 
 function sortByPublisher() {
   hideInfo();
-  $('article').sortElements(function(a, b){
-    pub_a = $(a).find('p[itemprop="publisher"]')[0].textContent.trim();
-    title_a = $(a).find('h2')[0].textContent.trim();
-    sort_key_a = pub_a.trim() + "__" + title_a.trim().replace(/^(The )|(A )/, "");
-
-    pub_b = $(b).find('p[itemprop="publisher"]')[0].textContent.trim();
-    title_b = $(b).find('h2')[0].textContent.trim();
-    sort_key_b = pub_b.trim() + "__" + title_b.trim().replace(/^(The )|(A )/, "");
-
-    return sort_key_a.toLowerCase().localeCompare(sort_key_b.toLowerCase());
-  });
+  $('article').sortElements(publisherSort());
   $('#pub_sort').hide();
   $('#title_sort').show();
 }
@@ -99,15 +89,8 @@ function sortByPublisher() {
 function sortByTitle() {
   hideInfo();
   resetPublishers();
-  $('article').sortElements(function(a, b){
-    title_a = $(a).find('h2')[0].textContent.trim();
-    sort_key_a = title_a.trim().replace(/^(The )|(A )/, "");
+  $('article').sortElements(titleSort());
 
-    title_b = $(b).find('h2')[0].textContent.trim();
-    sort_key_b = title_b.trim().replace(/^(The )|(A )/, "");
-
-    return sort_key_a.toLowerCase().localeCompare(sort_key_b.toLowerCase());
-  });
   $('#title_sort').hide();
   $('#pub_sort').show();
 }
@@ -198,3 +181,29 @@ $.expr[":"].contains = $.expr.createPseudo(function(arg) {
     return $(elem).text().toUpperCase().indexOf(arg.toUpperCase()) >= 0;
   };
 });
+
+function titleSort() {
+  return function(a, b){
+    title_a = $(a).find('h2')[0].textContent.trim();
+    sort_key_a = title_a.trim().replace(/^(The )|(A )/, "");
+
+    title_b = $(b).find('h2')[0].textContent.trim();
+    sort_key_b = title_b.trim().replace(/^(The )|(A )/, "");
+
+    return sort_key_a.toLowerCase().localeCompare(sort_key_b.toLowerCase());
+  }
+}
+
+function publisherSort() {
+  return function(a, b){
+    pub_a = $(a).find('p[itemprop="publisher"]')[0].textContent.trim();
+    title_a = $(a).find('h2')[0].textContent.trim();
+    sort_key_a = pub_a.trim() + "__" + title_a.trim().replace(/^(The )|(A )/, "");
+
+    pub_b = $(b).find('p[itemprop="publisher"]')[0].textContent.trim();
+    title_b = $(b).find('h2')[0].textContent.trim();
+    sort_key_b = pub_b.trim() + "__" + title_b.trim().replace(/^(The )|(A )/, "");
+
+    return sort_key_a.toLowerCase().localeCompare(sort_key_b.toLowerCase());
+  }
+}

--- a/bin/style/style.scss
+++ b/bin/style/style.scss
@@ -19,6 +19,26 @@ header {
   width: 100%;
   height: 120px;
   z-index: 10;
+
+  p {
+    margin: 0.5em 0;
+  }
+
+  nav .row {
+    display: flex;
+    flex: 200px;
+
+    div#search {
+      flex-grow: 2;
+      padding-left: 2em;
+    }
+  }
+
+  div#select_info {
+    flex: 100%;
+    max-width: 100%;
+    align-content: space-around;
+  }
 }
 
 a { text-decoration: none; }

--- a/bin/views/index.html.erb
+++ b/bin/views/index.html.erb
@@ -28,8 +28,8 @@
             </div>
           </div>
           <div id="search">
-            <form id="author_search" action="javascript: searchAuthors(this);">
-              <label for="search_box">Search by author name</label><br>
+            <form id="book_search" action="javascript: searchBooks(this);">
+              <label for="search_box">Search</label><br>
               <input id="search_box" type="textbox">
               <button type="submit" id="search_button">Search</button>
             </form>

--- a/bin/views/index.html.erb
+++ b/bin/views/index.html.erb
@@ -11,18 +11,29 @@
     <header>
       <p>Generated with <a href="https://github.com/lizconlan/bookshelf">github.com/lizconlan/<strong>bookshelf</strong></a> on <time><%= Time.now.asctime %></time>.</p>
       <nav>
-        <div id="filters">
-          <form>
-            <label for="pubfilter">Filter by publisher</label>
-            <select id="pubfilter" class="pubfilter">
-              <option>Show All</option><% @publishers.each do |pub| %>
-              <option><%= pub == "" ? Bookshelf::SELFPUB_NAME : pub %></option><% end %>
-            </select>
-          </form>
-        </div>
-        <div id="sort">
-          <a id="pub_sort" href="#">Sort by Publisher</a>
-          <a id="title_sort" href="#">Sort by Title</a>
+        <div class="row">
+          <div>
+            <div id="filters">
+              <form>
+                <label for="pubfilter">Filter by publisher</label><br>
+                <select id="pubfilter" class="pubfilter">
+                  <option>Show All</option><% @publishers.each do |pub| %>
+                  <option><%= pub == "" ? Bookshelf::SELFPUB_NAME : pub %></option><% end %>
+                </select>
+              </form>
+            </div>
+            <div id="sort">
+              <a id="pub_sort" href="#">Sort by Publisher</a>
+              <a id="title_sort" href="#">Sort by Title</a>
+            </div>
+          </div>
+          <div id="search">
+            <form id="author_search" action="javascript: searchAuthors(this);">
+              <label for="search_box">Search by author name</label><br>
+              <input id="search_box" type="textbox">
+              <button type="submit" id="search_button">Search</button>
+            </form>
+          </div>
         </div>
         <div id="select_info"></div>
       </nav>

--- a/bin/views/index.html.erb
+++ b/bin/views/index.html.erb
@@ -35,7 +35,7 @@
             </form>
           </div>
         </div>
-        <div id="select_info"></div>
+        <div id="nav_info"></div>
       </nav>
     </header>
     <section id="books">


### PR DESCRIPTION
Tidies up the UI a bit.

Adds a JavaScript powered (basic, looks for a partial string match) search with result sorting and search operators.

Kinda makes the README file out of date but I've grown fond of the original text and want to think about how to rewrite it rather than fixing it here.

### Examples

A search for "ruby" shows books with "Ruby" in the author or title field

<img width="1035" alt="Screenshot 2020-08-14 at 20 42 03" src="https://user-images.githubusercontent.com/27760/90286959-c1f43f80-de6e-11ea-972e-8e4ed508ebc6.png">

A search for "title: ruby" just shows books with "Ruby" in the title

<img width="1058" alt="Screenshot 2020-08-14 at 20 45 15" src="https://user-images.githubusercontent.com/27760/90287120-21524f80-de6f-11ea-9af6-302325de9a1b.png">

A search for "author: ruby" just shows the books where "Ruby" is in the name of one of the authors (these are tech books, after all - there's an assumption of multiple authors)

<img width="624" alt="Screenshot 2020-08-14 at 20 47 26" src="https://user-images.githubusercontent.com/27760/90287267-65455480-de6f-11ea-89e1-c8ac4db2fb13.png">

